### PR TITLE
using osx_fix itk branch

### DIFF
--- a/Superbuild/ITKExternal.cmake
+++ b/Superbuild/ITKExternal.cmake
@@ -84,7 +84,7 @@ IF(BUILD_MOSAIC_TOOLS)
   )
 ENDIF()
 
-SET(itk_GIT_TAG "origin/master")
+SET(itk_GIT_TAG "origin/osx_fix")
 
 # If CMake ever allows overriding the checkout command or adding flags,
 # git checkout -q will silence message about detached head (harmless).


### PR DESCRIPTION
This is a temporary fix to the build failure in osx 10.12.  I changed the line in ITK that was failing