### PR TITLE
NrrdDoubleClick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
 DartConfiguration.tcl
+xCode_bin

--- a/src/Interface/Application/ApplicationInterface.cc
+++ b/src/Interface/Application/ApplicationInterface.cc
@@ -640,7 +640,11 @@ void ApplicationInterface::handle_osx_file_open_event (std::string filename)
   {
     std::vector<std::string> project_file_extensions = Project::GetProjectFileExtensions();
 
-    this->open_initial_project (filename);
+    //this->open_initial_project (filename);
+     
+    if (this->open_initial_project (filename)){
+      this->private_->splash_screen_->close();
+    }
   }
 }
 

--- a/src/Interface/Application/ApplicationInterface.cc
+++ b/src/Interface/Application/ApplicationInterface.cc
@@ -625,26 +625,19 @@ void ApplicationInterface::handle_osx_file_open_event (std::string filename)
   {
     new_session = false;
   }
+    
+  boost::filesystem::path app_filepath;
+  Core::Application::Instance()->get_application_filepath( app_filepath );
+    
+  std::string command = std::string( "" ) +
+  app_filepath.parent_path().parent_path().string() + "/Contents/MacOS/Seg3D2 \"" + filename + "\" &";
+    
+  system( command.c_str() );
 
-  if ( !new_session )
+  if ( new_session )
   {
-    boost::filesystem::path app_filepath;
-    Core::Application::Instance()->get_application_filepath( app_filepath );
-
-    std::string command = std::string( "" ) +
-    app_filepath.parent_path().parent_path().string() + "/Contents/MacOS/Seg3D2 \"" + filename + "\" &";
-
-    system( command.c_str() );
-  }
-  else
-  {
-    std::vector<std::string> project_file_extensions = Project::GetProjectFileExtensions();
-
-    //this->open_initial_project (filename);
-     
-    if (this->open_initial_project (filename)){
-      this->private_->splash_screen_->close();
-    }
+      //kill this instance of Seg3D
+      this->close();
   }
 }
 

--- a/src/Interface/Application/ApplicationInterface.cc
+++ b/src/Interface/Application/ApplicationInterface.cc
@@ -186,7 +186,6 @@ ApplicationInterface::ApplicationInterface( std::string file_to_view_on_open ) :
   this->private_->tools_dock_window_ = new ToolsDockWidget( this );
   this->addDockWidget( Qt::LeftDockWidgetArea, this->private_->tools_dock_window_ );
 
-
   // Connect the windows and widgets to their visibility states
   QtUtils::QtBridge::Show( this->private_->rendering_dock_window_,
     InterfaceManager::Instance()->rendering_dockwidget_visibility_state_ );
@@ -636,7 +635,6 @@ void ApplicationInterface::handle_osx_file_open_event (std::string filename)
 
   if ( new_session )
   {
-      //kill this instance of Seg3D
       this->close();
   }
 }

--- a/src/Interface/Application/ApplicationInterface.cc
+++ b/src/Interface/Application/ApplicationInterface.cc
@@ -689,7 +689,7 @@ bool ApplicationInterface::open_initial_project ( std::string filename )
     // No location is set, so no project will be generated on disk for now
     ActionNewProject::Dispatch( Core::Interface::GetWidgetActionContext(),
                                 "", "Untitled Project" );
-    LayerIOFunctions::ImportFiles( NULL, filename );
+    LayerIOFunctions::ImportFiles( this, filename );
     return true;
   }
 

--- a/src/Interface/Application/ApplicationInterface.cc
+++ b/src/Interface/Application/ApplicationInterface.cc
@@ -616,27 +616,25 @@ void ApplicationInterface::HandleCriticalErrorMessage( qpointer_type qpointer, i
 
 void ApplicationInterface::handle_osx_file_open_event (std::string filename)
 {
-  Seg3D::ProjectHandle current_project = Seg3D::ProjectManager::Instance()->get_current_project();
-
   // must do this to make sure a double-click on a project file doesn't use this executable session
-  bool new_session = InterfaceManager::Instance()->splash_screen_visibility_state_->get();
+  bool useCurrentSession = InterfaceManager::Instance()->splash_screen_visibility_state_->get();
   if ( !this->private_->splash_screen_ || this->private_->splash_screen_->get_user_interacted() )
   {
-    new_session = false;
+    useCurrentSession = false;
   }
     
+  if ( useCurrentSession )
+  {
+    this->close();
+  }
+
   boost::filesystem::path app_filepath;
   Core::Application::Instance()->get_application_filepath( app_filepath );
     
-  std::string command = std::string( "" ) +
-  app_filepath.parent_path().parent_path().string() + "/Contents/MacOS/Seg3D2 \"" + filename + "\" &";
+  std::string command = app_filepath.parent_path().parent_path().string()
+      + "/Contents/MacOS/Seg3D2 \"" + filename + "\" &";
     
   system( command.c_str() );
-
-  if ( new_session )
-  {
-      this->close();
-  }
 }
 
 

--- a/src/Interface/Application/LayerImporterWidget.ui
+++ b/src/Interface/Application/LayerImporterWidget.ui
@@ -180,8 +180,8 @@
                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600;&quot;&gt;Data Volume&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt;: The data will be displayed as solid volume of gray scale values. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600; color:#ffffff;&quot;&gt;Data Volume&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt;: The data will be displayed as solid volume of gray scale values. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="textFormat">
                <enum>Qt::RichText</enum>
@@ -283,8 +283,8 @@ p, li { white-space: pre-wrap; }
                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600;&quot;&gt;Single Mask:&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt; The mask will be created by thresholding all the non zero values as selected.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600; color:#ffffff;&quot;&gt;Single Mask:&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt; The mask will be created by thresholding all the non zero values as selected.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="textFormat">
                <enum>Qt::RichText</enum>
@@ -386,8 +386,8 @@ p, li { white-space: pre-wrap; }
                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600;&quot;&gt;Series of Masks:&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt; Each mask is defined by a bit plane in the data file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600; color:#ffffff;&quot;&gt;Series of Masks:&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt; Each mask is defined by a bit plane in the data file.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="textFormat">
                <enum>Qt::RichText</enum>
@@ -489,8 +489,8 @@ p, li { white-space: pre-wrap; }
                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600;&quot;&gt;Series of Masks&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt;&quot;&gt;: Each unique label in the mask will be given a separate mask.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'.SF NS Text'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt;Import file as a &lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; font-weight:600; color:#ffffff;&quot;&gt;Series of Masks&lt;/span&gt;&lt;span style=&quot; font-family:'Lucida Grande'; font-size:10pt; color:#ffffff;&quot;&gt;: Each unique label in the mask will be given a separate mask.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="textFormat">
                <enum>Qt::RichText</enum>


### PR DESCRIPTION
OS X doesn’t crash anymore, but there is a very brief flash of the previous instance of Seg3D opening and closing. This will be fixed in the next release. Also, the import screen was fixed to show white text.