### PR TITLE
Exporter fixes

### DIFF
--- a/src/Application/LayerIO/ITKDataLayerExporter.cc
+++ b/src/Application/LayerIO/ITKDataLayerExporter.cc
@@ -211,7 +211,7 @@ bool export_image_series( const std::string& file_path,
   typename ImageType::IndexType start = region.GetIndex();
   typename ImageType::SizeType size = region.GetSize();
  
-  if (size[1] == 0 || size[2] == 0 || size[3] == 0)
+  if (size[0] == 0 || size[1] == 0 || size[2] == 0)
   {
     return false;
   }

--- a/src/Application/LayerIO/ITKDataLayerExporter.cc
+++ b/src/Application/LayerIO/ITKDataLayerExporter.cc
@@ -38,6 +38,7 @@
 #include <itkMetaDataObject.h>
 #include <itkRescaleIntensityImageFilter.h>
 #include <itkCastImageFilter.h>
+#include <itkMinimumMaximumImageCalculator.h>
 
 // GDCM includes
 #include <gdcmImageHelper.h>
@@ -75,8 +76,13 @@ cast_image( typename Core::ITKImageDataT< InputPixelType >::Handle image_data )
   typedef itk::RescaleIntensityImageFilter< InputImageType, InputImageType > RescaleType;
   typename RescaleType::Pointer rescale = RescaleType::New();
 
+  //static_assert((std::is_unsigned<InputPixelType>::value && std::is_unsigned<OutputPixelType>::value) 
+    //|| (std::is_signed<InputPixelType>::value && std::is_signed<OutputPixelType>::value), "Signed/unsigned mismatch");
+
   // assumes casting to type with smaller range...
   rescale->SetInput( itk_image );
+  rescale->Update();
+
   rescale->SetOutputMinimum( itk::NumericTraits< OutputPixelType >::min() );
   // TODO: problem for PNG?
   rescale->SetOutputMaximum( itk::NumericTraits< OutputPixelType >::max() );
@@ -85,6 +91,38 @@ cast_image( typename Core::ITKImageDataT< InputPixelType >::Handle image_data )
   typename CastFilterType::Pointer castFilter = CastFilterType::New();
   castFilter->SetInput( rescale->GetOutput() );
   castFilter->Update();
+
+  return castFilter->GetOutput();
+}
+
+template< class InputPixelType, class OutputPixelType >
+typename itk::Image< OutputPixelType, DIM_3D >::Pointer
+direct_cast_image(typename Core::ITKImageDataT< InputPixelType >::Handle image_data)
+{
+  typedef itk::Image< InputPixelType, DIM_3D > InputImageType;
+  typedef itk::Image< OutputPixelType, DIM_3D > OutputImageType;
+  typedef typename Core::ITKImageDataT< OutputPixelType > OutputType;
+
+  typename InputImageType::Pointer itk_image = image_data->get_image();
+
+  typedef itk::MinimumMaximumImageCalculator<InputImageType> MinimumMaximumImageCalculatorType;
+  typename MinimumMaximumImageCalculatorType::Pointer MinMaxCalc = MinimumMaximumImageCalculatorType::New();
+  MinMaxCalc->SetImage(itk_image);
+  MinMaxCalc->Compute();
+  auto inputMain = MinMaxCalc->GetMinimum();
+  auto inputMax = MinMaxCalc->GetMaximum();
+
+  typedef itk::CastImageFilter< InputImageType, OutputImageType > CastFilterType;
+  typename CastFilterType::Pointer castFilter = CastFilterType::New();
+  castFilter->SetInput(itk_image);
+  castFilter->Update();
+
+  typedef itk::MinimumMaximumImageCalculator<OutputImageType> MinimumMaximumImageCalculatorCastType;
+  auto MinMaxCalcCast = MinimumMaximumImageCalculatorCastType::New();
+  MinMaxCalcCast->SetImage(castFilter->GetOutput());
+  MinMaxCalcCast->Compute();
+  auto inputMain_1 = MinMaxCalcCast->GetMinimum();
+  auto inputMax_1 = MinMaxCalcCast->GetMaximum();
 
   return castFilter->GetOutput();
 }
@@ -459,11 +497,12 @@ bool ITKDataLayerExporter::export_layer_internal( const std::string& file_path,
                    temp_handle->get_grid_transform() ) );
 
   bool success = false;
-  if ( this->extension_ == ".dcm" )
+  if ( this->extension_ == ".dcm" || this->extension_ == ".dicom" || this->extension_ == ".ima")
   {
     if ( this->pixel_type_ == Core::DataType::FLOAT_E || this->pixel_type_ == Core::DataType::DOUBLE_E ||
          this->pixel_type_ == Core::DataType::ULONGLONG_E || this->pixel_type_ == Core::DataType::LONGLONG_E )
     {
+      //investigate unsigned long long to int conversion
       typename itk::Image< int, DIM_3D >::Pointer new_image_data = cast_image< InputPixelType, int >( image_data );
       success =  export_dicom_series< int >( file_path, name, new_image_data, temp_handle, this->extension_ );
     }
@@ -494,7 +533,7 @@ bool ITKDataLayerExporter::export_layer_internal( const std::string& file_path,
     if (! ( this->pixel_type_ == Core::DataType::CHAR_E || this->pixel_type_ == Core::DataType::UCHAR_E ||
             this->pixel_type_ == Core::DataType::USHORT_E ) )
     {
-      typename itk::Image< unsigned short, DIM_3D >::Pointer new_image_data = cast_image< InputPixelType, unsigned short >( image_data );
+      typename itk::Image< unsigned short, DIM_3D >::Pointer new_image_data = cast_image< InputPixelType, unsigned short >(image_data);
       success = export_image_series< unsigned short >( file_path, name, new_image_data, this->extension_ );
     }
     else

--- a/src/Application/LayerIO/ITKDataLayerExporter.cc
+++ b/src/Application/LayerIO/ITKDataLayerExporter.cc
@@ -458,17 +458,18 @@ bool ITKDataLayerExporter::export_layer_internal( const std::string& file_path,
     new ImageData( temp_handle->get_data_volume()->get_data_block(),
                    temp_handle->get_grid_transform() ) );
 
+  bool success = false;
   if ( this->extension_ == ".dcm" )
   {
     if ( this->pixel_type_ == Core::DataType::FLOAT_E || this->pixel_type_ == Core::DataType::DOUBLE_E ||
          this->pixel_type_ == Core::DataType::ULONGLONG_E || this->pixel_type_ == Core::DataType::LONGLONG_E )
     {
       typename itk::Image< int, DIM_3D >::Pointer new_image_data = cast_image< InputPixelType, int >( image_data );
-      return export_dicom_series< int >( file_path, name, new_image_data, temp_handle, this->extension_ );
+      success =  export_dicom_series< int >( file_path, name, new_image_data, temp_handle, this->extension_ );
     }
     else
     {
-      return export_dicom_series< InputPixelType >( file_path, name, image_data->get_image(), temp_handle, this->extension_ );
+      success =  export_dicom_series< InputPixelType >( file_path, name, image_data->get_image(), temp_handle, this->extension_ );
     }
   }
   else if ( this->extension_ == ".tiff" || this->extension_ == ".tif" )
@@ -476,16 +477,16 @@ bool ITKDataLayerExporter::export_layer_internal( const std::string& file_path,
     if ( this->pixel_type_ == Core::DataType::DOUBLE_E)
     {
       typename itk::Image< float, DIM_3D >::Pointer new_image_data = cast_image< InputPixelType, float >( image_data );
-      return export_image_series< float >( file_path, name, new_image_data, this->extension_ );
+      success = export_image_series< float >( file_path, name, new_image_data, this->extension_ );
     }
     else if ( this->pixel_type_ == Core::DataType::ULONGLONG_E || this->pixel_type_ == Core::DataType::LONGLONG_E )
     {
       typename itk::Image< int, DIM_3D >::Pointer new_image_data = cast_image< InputPixelType, int >( image_data );
-      return export_image_series< int >( file_path, name, new_image_data, this->extension_ );
+      success = export_image_series< int >( file_path, name, new_image_data, this->extension_ );
     }
     else
     {
-      return export_image_series< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
+      success = export_image_series< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
     }
   }
   else if ( this->extension_ == ".png" )
@@ -494,25 +495,25 @@ bool ITKDataLayerExporter::export_layer_internal( const std::string& file_path,
             this->pixel_type_ == Core::DataType::USHORT_E ) )
     {
       typename itk::Image< unsigned short, DIM_3D >::Pointer new_image_data = cast_image< InputPixelType, unsigned short >( image_data );
-      return export_image_series< unsigned short >( file_path, name, new_image_data, this->extension_ );
+      success = export_image_series< unsigned short >( file_path, name, new_image_data, this->extension_ );
     }
     else
     {
-      return export_image_series< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
+      success = export_image_series< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
     }
   }
   else if ( this->extension_ == ".nii" || this->extension_ == ".nii.gz" || this->extension_ == ".mha" )
   {
     // supports all
-    return export_volume< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
+    success =  export_volume< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
   }
   else if ( ! this->extension_.empty() )
   {
-    return export_image_series< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
+    success = export_image_series< InputPixelType >( file_path, name, image_data->get_image(), this->extension_ );
   }
 
-  CORE_LOG_SUCCESS( "Data export has been successfully completed." );
-  return true;
+  if (success) CORE_LOG_SUCCESS("Data export has been successfully completed.");
+  return success;
 }
 
 bool ITKDataLayerExporter::export_layer( const std::string& mode, const std::string& file_path, const std::string& name )

--- a/src/Application/LayerIO/ITKDataLayerExporter.cc
+++ b/src/Application/LayerIO/ITKDataLayerExporter.cc
@@ -211,7 +211,7 @@ bool export_image_series( const std::string& file_path,
   typename ImageType::IndexType start = region.GetIndex();
   typename ImageType::SizeType size = region.GetSize();
  
-  if (size[1] || size[2] || size[3])
+  if (size[1] == 0 || size[2] == 0 || size[3] == 0)
   {
     return false;
   }

--- a/src/Application/LayerIO/ITKMaskLayerExporter.cc
+++ b/src/Application/LayerIO/ITKMaskLayerExporter.cc
@@ -327,10 +327,8 @@ bool export_mask_volume( const std::string& file_path,
                          typename itk::Image< PixelType, DIM_3D >::Pointer itk_image )
 {
   boost::filesystem::path path = boost::filesystem::path( file_path );
-
   boost::filesystem::path full_filename( file_name );
-  std::string extension, base;
-  std::tie( extension, base ) = Core::GetFullExtension( full_filename );
+  boost::filesystem::path filename_path = path / full_filename;
 
   typedef itk::Image< PixelType, DIM_3D > ImageType;
   typedef itk::ImageFileWriter< ImageType > WriterType;
@@ -338,7 +336,7 @@ bool export_mask_volume( const std::string& file_path,
   typename WriterType::Pointer writer = WriterType::New();
 
   writer->SetInput( itk_image );
-  writer->SetFileName( full_filename.string() );
+  writer->SetFileName(filename_path.string());
 
   try
   {
@@ -439,6 +437,7 @@ bool ITKMaskLayerExporter::export_layer_internal( const std::string& mode,
       success =  export_mask_volume<InputPixelType>( file_path, ( mask->get_layer_name() + this->extension_ ), image_data->get_image() );
     }
 
+    if (success) CORE_LOG_SUCCESS("Segmentation export has been successfully completed.");
     return success;
   }
   else
@@ -471,10 +470,10 @@ bool ITKMaskLayerExporter::export_layer_internal( const std::string& mode,
       }
     }
 
+    if (success) CORE_LOG_SUCCESS("Segmentation export has been successfully completed.");
     return success;
   }
 
-  CORE_LOG_SUCCESS( "Segmentation export has been successfully completed." );
 
   // If we have successfully gone through all the layers return true
   return true;


### PR DESCRIPTION
ITK exporters are now functional. Error handling for signed to unsigned mismatches. No longer crashes when trying to export a signed short image to PNG. 