### PR TITLE
Fix typos in src/Core

### DIFF
--- a/src/Core/Action/Action.h
+++ b/src/Core/Action/Action.h
@@ -91,7 +91,7 @@ public:
   // provided for each sub class of this class. Hence that also explains why the get_action_info
   // function is virtual. It accesses the record from the derived class.
   
-  // GET_DEFINTION:
+  // GET_DEFINITION:
   /// Get the definition of the action (in XML format)
   std::string get_definition() const;
   

--- a/src/Core/Action/ActionContext.h
+++ b/src/Core/Action/ActionContext.h
@@ -123,7 +123,7 @@ typedef boost::shared_ptr< ActionContext > ActionContextHandle;
 /// entity with a pointer to the Action which describes the action that needs
 /// to be done. Action itself contains the pointers to the functions that need
 /// to be executed and with which parameters, but not where to report errors,
-/// the source of the action ect. The latter information is contained in the
+/// the source of the action etc. The latter information is contained in the
 /// ActionContext. Each source needs to derive its own ActionContext from this
 /// class and generate the specifics of where information needs to be relayed
 /// to.

--- a/src/Core/Action/ActionHistory.h
+++ b/src/Core/Action/ActionHistory.h
@@ -49,7 +49,7 @@ namespace Core
 // Forward Declaration
 class ActionHistory;
 
-// Class defintion
+// Class definition
 class ActionHistory : public Lockable
 {
   CORE_SINGLETON( ActionHistory );

--- a/src/Core/DataBlock/DataBlock.h
+++ b/src/Core/DataBlock/DataBlock.h
@@ -221,7 +221,7 @@ public:
   void set_histogram( const Histogram& histogram );
 
   // SWAP_ENDIAN:
-  /// Swap the endianess of the data
+  /// Swap the endianness of the data
   void swap_endian();
 
 private:

--- a/src/Core/DataBlock/Histogram.h
+++ b/src/Core/DataBlock/Histogram.h
@@ -112,7 +112,7 @@ public:
   const std::vector<size_t>& get_bins() const;
 
   // IS_VALID:
-  /// Check whther histogram is valid
+  /// Check whether histogram is valid
   bool is_valid() const;
 
 private:

--- a/src/Core/DataBlock/ITKImage2DData.h
+++ b/src/Core/DataBlock/ITKImage2DData.h
@@ -89,7 +89,7 @@ public:
   virtual Transform get_transform() const = 0;
 
   // SET_TRANSFORM:
-  /// Set the transfrom in the nrrd data
+  /// Set the transform in the nrrd data
   virtual void set_transform( Transform& transform, SliceType slice = SliceType::AXIAL_E  ) = 0;
 
   // GET_NX, GET_NY:
@@ -164,7 +164,7 @@ public:
   virtual Transform get_transform() const;
 
   // SET_TRANSFORM:
-  /// Set the transfrom in the nrrd data
+  /// Set the transform in the nrrd data
   virtual void set_transform( Transform& transform, SliceType slice = SliceType::AXIAL_E );
 
   // GET_NX, GET_NY:

--- a/src/Core/DataBlock/ITKImageData.h
+++ b/src/Core/DataBlock/ITKImageData.h
@@ -89,7 +89,7 @@ public:
   virtual Transform get_transform() const = 0;
 
   // SET_TRANSFORM:
-  /// Set the transfrom in the nrrd data
+  /// Set the transform in the nrrd data
   virtual void set_transform( Transform& transform ) = 0;
 
   // GET_NX, GET_NY, GET_NZ:
@@ -165,7 +165,7 @@ public:
   virtual Transform get_transform() const;
 
   // SET_TRANSFORM:
-  /// Set the transfrom in the nrrd data
+  /// Set the transform in the nrrd data
   virtual void set_transform( Transform& transform );
 
   // GET_NX, GET_NY, GET_NZ:

--- a/src/Core/DataBlock/NrrdData.h
+++ b/src/Core/DataBlock/NrrdData.h
@@ -110,7 +110,7 @@ public:
   Transform get_transform() const;
 
   // SET_TRANSFORM:
-  /// Set the transfrom in the nrrd data
+  /// Set the transform in the nrrd data
   void set_transform( GridTransform& transform, bool no_downgrade );
 
   // GET_HISTOGRAM:

--- a/src/Core/EventHandler/DefaultEventHandlerContext.h
+++ b/src/Core/EventHandler/DefaultEventHandlerContext.h
@@ -55,7 +55,7 @@ class DefaultEventHandlerContext : public EventHandlerContext
 
 public:
 
-  // Constuctor and destructor
+  // Constructor and destructor
   DefaultEventHandlerContext();
   virtual ~DefaultEventHandlerContext();
 

--- a/src/Core/EventHandler/Event.h
+++ b/src/Core/EventHandler/Event.h
@@ -45,7 +45,7 @@ namespace Core
 {
 
 // CLASS EVENTSYNC:
-/// Auxilary class needed for doing synchronization
+/// Auxiliary class needed for doing synchronization
 
 class EventSync
 {
@@ -96,7 +96,7 @@ private:
 
 // CLASS EVENTT <TEMPLATE>
 /// This class is redefined for each functor and contains only the
-/// pointer to the function object. It is generated on the fly whereever
+/// pointer to the function object. It is generated on the fly wherever
 /// the compiler needs it. 
 
 template< class FUNCTOR >

--- a/src/Core/EventHandler/EventHandlerContext.h
+++ b/src/Core/EventHandler/EventHandlerContext.h
@@ -58,7 +58,7 @@ class EventHandlerContext : public boost::noncopyable
 
 public:
 
-  // Constuctor and destructor for class that can be overloaded
+  // Constructor and destructor for class that can be overloaded
   EventHandlerContext()
   {
   }

--- a/src/Core/Geometry/GridTransform.h
+++ b/src/Core/Geometry/GridTransform.h
@@ -51,7 +51,7 @@ namespace Core
 
 class GridTransform : public Transform
 {
-  // -- constuctors --
+  // -- constructors --
 public:
   GridTransform();
 

--- a/src/Core/Geometry/Matrix.h
+++ b/src/Core/Geometry/Matrix.h
@@ -107,7 +107,7 @@ public:
 private:
   double data_[16];
 
-  // static funtions
+  // static functions
 public:
   // INVERT:
   /// Compute the inverse of the input matrix using LU decomposition
@@ -193,7 +193,7 @@ public:
 private:
   float data_[16];
 
-  // static funtions
+  // static functions
 public:
 
   // INVERT:

--- a/src/Core/Geometry/Point.h
+++ b/src/Core/Geometry/Point.h
@@ -49,7 +49,7 @@ namespace Core
 /// geometric expressions. 
 
 // NOTE: The double version of Point and Vector are defined separately. As Vector
-// and Point are dependent on each other, a templated version is limitted by the
+// and Point are dependent on each other, a templated version is limited by the
 // need to include templated member function, and templated member functions
 // current can only be defined inside the template (a limitation of the 
 // C++ language). Hence to keep code readable and organized we have two versions

--- a/src/Core/ITKCommon/AsyncMosiacSave.h
+++ b/src/Core/ITKCommon/AsyncMosiacSave.h
@@ -30,7 +30,7 @@
 // Author       : Bradley C. Grimm
 // Created      : 2009/06/25
 // Copyright    : (C) 2009 University of Utah
-// Description  : An asyncronous save manager so that ir-assemble
+// Description  : An asynchronous save manager so that ir-assemble
 //                progress is not halted with each save.
 
 #ifndef __ASYNC_MOSAIC_SAVE_H__

--- a/src/Core/ITKCommon/FFT/fft_common.cxx
+++ b/src/Core/ITKCommon/FFT/fft_common.cxx
@@ -274,7 +274,7 @@ find_maxima_cm(std::list<local_max_t> & max_list,
         unsigned int cluster_id = cluster_map[u * h + v];
         if (cluster_id == i || cluster_id == static_cast<unsigned int>(~0)) continue;
 
-        // figure out which boundaries this cluster was broken accross:
+        // figure out which boundaries this cluster was broken across:
         cluster_bbox_t & ba = bboxes[i];
         cluster_bbox_t & bb = bboxes[cluster_id];
 

--- a/src/Core/ITKCommon/Optimizers/itkImageMosaicVarianceMetric.h
+++ b/src/Core/ITKCommon/Optimizers/itkImageMosaicVarianceMetric.h
@@ -50,7 +50,7 @@
     same type (and therefore have the same number of parameters). Some
     of the transforms parameters may be shared across transforms. The
     shared/unique parameters are specified by a bit vector
-    (true - shared, false - unique). This is usefull for radial
+    (true - shared, false - unique). This is useful for radial
     distortion transforms where the translation parameters are unique
     for each image but the distortion parameters are the same across
     all images (all images are assumed to have been distorted by
@@ -272,7 +272,7 @@ public:
   // image gradients:
   std::vector<typename gradient_image_t::ConstPointer> gradient_;
 
-  // adresses of the individual transform parameter indices within the
+  // addresses of the individual transform parameter indices within the
   // concatenated parameter vector:
   std::vector<std::vector<unsigned int> > address_;
 

--- a/src/Core/ITKCommon/STOS/stos_common.hxx
+++ b/src/Core/ITKCommon/STOS/stos_common.hxx
@@ -459,7 +459,7 @@ public:
                                                            clahe_window);
 
         // NOTE: this was added per James request --  don't clip
-        // againt the child node if it is a leaf node.
+        // against the child node if it is a leaf node.
         if (!link.b_->children_.empty())
         {
           // clip this nodes mask against the childs mask:

--- a/src/Core/ITKCommon/ThreadUtils/the_thread_interface.cxx
+++ b/src/Core/ITKCommon/ThreadUtils/the_thread_interface.cxx
@@ -435,7 +435,7 @@ the_thread_interface_t::work()
     {
       active_transaction_ = nullptr;
 #ifdef DEBUG_THREAD
-      cerr << "FIXME: caught unknonwn exception" << endl;
+      cerr << "FIXME: caught unknown exception" << endl;
 #endif
       t->notify(this,
     the_transaction_t::ABORTED_E,

--- a/src/Core/ITKCommon/Transform/IRRefineTranslateCanvas.cxx
+++ b/src/Core/ITKCommon/Transform/IRRefineTranslateCanvas.cxx
@@ -137,7 +137,7 @@ fillTransformAndImageIDVectors(TrasformBasePointerVector& transforms,
 //----------------------------------------------------------------
 // IRRefineTranslateCanvas::fillTransformAndImageIDVectors
 //
-// silly other version that uses a list because fo some reason
+// silly other version that uses a list because for some reason
 // paul likes using lists for the image IDs........
 //
 void
@@ -410,7 +410,7 @@ IRRefineTranslateCanvas::getConectionToProcess()
   if (_preProcessedConnectionVector.size() > 0)
   {
     // by picking out  random connection we have less of a chance
-    // to keep on picking connection with the same trasformation
+    // to keep on picking connection with the same transformation
     // and thus not having good multithreaded performance because
     // multiple threads are waiting for the same image to load
     int element;
@@ -468,7 +468,7 @@ setTransformAndNeighborsToGroupID(IRTransform* transform, long groupID)
       {
         if (neighbor->groupID() != -1)
         {
-          printf("Error! why was this groupID aready set!");
+          printf("Error! why was this groupID already set!");
         }
 
         transformStack.push(neighbor);

--- a/src/Core/ITKCommon/Transform/IRRefineTranslateCanvas.hxx
+++ b/src/Core/ITKCommon/Transform/IRRefineTranslateCanvas.hxx
@@ -92,7 +92,7 @@ public:
                                       TheTextVector& imageIDs,
                                       TheTextVector& maskIDs);
   
-  // silly other version that uses a list because fo some reason
+  // silly other version that uses a list because for some reason
   // paul likes using lists for the list of image IDs........
   void fillTransformAndImageIDVectors(TrasformBasePointerVector& transforms,
                                       TheTextList& imageIDs,

--- a/src/Core/ITKCommon/Transform/IRTransform.hxx
+++ b/src/Core/ITKCommon/Transform/IRTransform.hxx
@@ -71,7 +71,7 @@ public:
   
   bool overlapsTransform(const IRTransform* otherTransform) const;
   
-  // sets start and size to the area that is covered by otherTransfrom,
+  // sets start and size to the area that is covered by otherTransform,
   // the value returned by this function are with respect the the corner of
   // the transformation.
   // if they don't overlap at all this function returns an error (-1)

--- a/src/Core/ITKCommon/Transform/itkCascadedTransform.h
+++ b/src/Core/ITKCommon/Transform/itkCascadedTransform.h
@@ -203,7 +203,7 @@ public:
       else
       {
         std::ostringstream oss;
-        oss << "Could not convert inverse tranform obtained from transform "
+        oss << "Could not convert inverse transform obtained from transform "
             << i << " from itkTransformBase to itkTransform. Skipping transform.";
         CORE_LOG_DEBUG(oss.str());
       }
@@ -364,7 +364,7 @@ private:
   // Cascaded transforms - input is first transformed by the first
   // transform, followed by the other transforms sequentially.
   // Only the top-most (last) transform in the array is accessible
-  // for modification, all preciding transforms are fixed.
+  // for modification, all preceding transforms are fixed.
   std::vector<TransformPointer> transform_;
 
   // This index controls which transform on the stack can be manipulated

--- a/src/Core/ITKCommon/Transform/itkLegendrePolynomialTransform.h
+++ b/src/Core/ITKCommon/Transform/itkLegendrePolynomialTransform.h
@@ -311,7 +311,7 @@ public:
     mask[index_b(0, 0)] = false;
   }
   
-  // Convert the j, k indeces associated with a(j, k) coefficient
+  // Convert the j, k indices associated with a(j, k) coefficient
   // into an index that can be used with the parameters array:
   inline static unsigned int index_a(const unsigned int & j,
                                      const unsigned int & k)

--- a/src/Core/ITKCommon/Transform/itkNumericInverse.h
+++ b/src/Core/ITKCommon/Transform/itkNumericInverse.h
@@ -183,7 +183,7 @@ private:
   // the transform whose inverse we are trying to evaluate:
   const TransformType & transform_;
   
-  // the point for which we are tryying to find the inverse mapping:
+  // the point for which we are trying to find the inverse mapping:
   mutable std::vector<ScalarType> y_;
 };
 

--- a/src/Core/ITKCommon/Transform/itkRBFTransform.h
+++ b/src/Core/ITKCommon/Transform/itkRBFTransform.h
@@ -180,7 +180,7 @@ public:
   inline unsigned int num_points() const
   { return (this->m_FixedParameters.size() - 4) / 2; }
   
-  // calculate parameter vector indeces for various transform parameters:
+  // calculate parameter vector indices for various transform parameters:
   inline static unsigned int index_a(const unsigned int & i)
   { return i * 2; }
   

--- a/src/Core/ITKCommon/Transform/itkRadialDistortionTransform.h
+++ b/src/Core/ITKCommon/Transform/itkRadialDistortionTransform.h
@@ -142,7 +142,7 @@ public:
   const ParametersType & GetParameters() const override
   { return this->m_Parameters; }
   
-  // virtual: mumber of parameters that define this transform:
+  // virtual: number of parameters that define this transform:
   virtual
   NumberOfParametersType GetNumberOfParameters() const override
   { return N + 2; }

--- a/src/Core/ITKCommon/cluster.cxx
+++ b/src/Core/ITKCommon/cluster.cxx
@@ -128,7 +128,7 @@ identify_clusters_cm(const double * data,
     centerofmass.push_back(cm);
   }
   
-  // sort the max points so that the best candidate is firts:
+  // sort the max points so that the best candidate is first:
   centerofmass.sort(std::greater<centerofmass_t<1> >());
   
   return !centerofmass.empty();

--- a/src/Core/ITKCommon/common.hxx
+++ b/src/Core/ITKCommon/common.hxx
@@ -205,7 +205,7 @@ typedef itk::Image<pixel_t, 2> image_t;
 //----------------------------------------------------------------
 // base_transform_t
 //
-// Shorthand for abstract 2D tranforms.
+// Shorthand for abstract 2D transforms.
 //
 typedef itk::Transform<double, 2, 2> base_transform_t;
 
@@ -2027,7 +2027,7 @@ my_metric(double & overlap,
 //    double area_a = calc_area(fi, fi_mask);
 //    double area_b = calc_area(mi, mi_mask);
 //#else
-    // this is fast, but approximate -- the mask is ingored,
+    // this is fast, but approximate -- the mask is ignored,
     // only the image dimensions and pixel spacing are used:
     double area_a = get_area<TImage>(fi);
     double area_b = get_area<TImage>(mi);
@@ -2724,7 +2724,7 @@ public:
                     // tile tint:
                     const std::vector<double> & tint,
 
-                    // tile trasforms:
+                    // tile transforms:
                     const std::vector<transform_pointer_t> & transform,
 
                     // tiles and tile masks
@@ -2914,7 +2914,7 @@ public:
   // tile tint:
   const std::vector<double> & tint_;
 
-  // tile trasforms:
+  // tile transforms:
   const std::vector<transform_pointer_t> & transform_;
 
   // tiles and tile masks
@@ -3534,7 +3534,7 @@ public:
                   // omitted tile flags:
                   const std::vector<bool> & omit,
 
-                  // tile trasforms:
+                  // tile transforms:
                   const std::vector<transform_pointer_t> & transform,
 
                   // tiles and tile masks
@@ -3635,7 +3635,7 @@ public:
   // omitted tile flags:
   const std::vector<bool> & omit_;
 
-  // tile trasforms:
+  // tile transforms:
   const std::vector<transform_pointer_t> & transform_;
 
   // tile masks

--- a/src/Core/ITKCommon/grid_common.hxx
+++ b/src/Core/ITKCommon/grid_common.hxx
@@ -134,9 +134,9 @@ estimate_displacement(double & best_metric, // current best metric
                       const TImage * a, // large image A
                       const TImage * b, // small image B
 
-                      // this could be the size of B (ususally when matching
+                      // this could be the size of B (usually when matching
                       // small neighborhoods in A and B), or the
-                      // maximum dimesions of A and B (plain image matching):
+                      // maximum dimensions of A and B (plain image matching):
                       const typename TImage::SizeType & period_sz,
 
                       const local_max_t & lm,
@@ -269,9 +269,9 @@ match_one_pair(translate_transform_t::Pointer & best_transform,
                const TImage * mi,
                const mask_t * mi_mask,
 
-               // this could be the size of B (ususally when matching
+               // this could be the size of B (usually when matching
                // small neighborhoods in A and B), or the
-               // maximum dimesions of A and B (plain image matching):
+               // maximum dimensions of A and B (plain image matching):
                const typename TImage::SizeType & period_sz,
 
                const double & overlap_min,

--- a/src/Core/ITKCommon/match.hxx
+++ b/src/Core/ITKCommon/match.hxx
@@ -630,7 +630,7 @@ match(const unsigned int order,
           // FIXME:
           bestfit_stats(ab, bestfit);
           
-          // re-solve for affine transform in order to accomodate the new
+          // re-solve for affine transform in order to accommodate the new
           // inliers detected due to the higher order polynomial coefficients
           // of the transform, then re-solve for the higher order
           // polynomial coefficients:

--- a/src/Core/ITKCommon/pyramid.cxx
+++ b/src/Core/ITKCommon/pyramid.cxx
@@ -302,7 +302,7 @@ generate_feature_vector_v0(// gradient image:
   
   static const double sqrt_two = sqrt(2.0);
   
-  // contrinution buffers:
+  // contribution buffers:
   static unsigned int col_addr[3];
   static unsigned int row_addr[3];
   static double col_w[3];
@@ -411,7 +411,7 @@ generate_feature_vector_v1(// gradient image:
   
   static const double sqrt_two = sqrt(2.0);
   
-  // contrinution buffers:
+  // contribution buffers:
   static double weight[9];
   
   // weight sigma:
@@ -560,7 +560,7 @@ generate_feature_vector_v2(// minima and maxima of a given octave scale:
   // section addresses in the feature vector:
   static const unsigned int address[] = { 0, 4, 16, 36, 64, 100 };
   
-  // indeces of the first and last annulus of the sampling window:
+  // indices of the first and last annulus of the sampling window:
   static const unsigned int a0 = 0;
   static const unsigned int a1 = annulai - 1;
   
@@ -1070,7 +1070,7 @@ generate_feature_vector_v5(// gradient image:
   
   static const double sqrt_two = sqrt(2.0);
   
-  // contrinution buffers:
+  // contribution buffers:
   static unsigned int col_addr[3];
   static unsigned int row_addr[3];
   static double col_w[3];
@@ -1176,7 +1176,7 @@ generate_feature_vector_v6(// gradient image:
   static const unsigned int rows = static_cast<unsigned int>(sqrt(static_cast<double>(KEY_SIZE / bins)));
   static const unsigned int cols = rows;
   
-  // contrinution buffers:
+  // contribution buffers:
   static unsigned int col_addr[3];
   static unsigned int row_addr[3];
   static double col_w[3];

--- a/src/Core/ITKCommon/the_dynamic_array.hxx
+++ b/src/Core/ITKCommon/the_dynamic_array.hxx
@@ -262,7 +262,7 @@ public:
   inline const T & operator [] (const size_t & i) const
   { return elem(i); }
   
-  // this is usefull for filling-in the array:
+  // this is useful for filling-in the array:
   the_dynamic_array_ref_t<T> operator << (const T & elem)
   {
     (*this)[0] = elem;

--- a/src/Core/Interface/Interface.h
+++ b/src/Core/Interface/Interface.h
@@ -55,7 +55,7 @@ class InterfacePrivate;
 // Private part of the class 
 typedef boost::shared_ptr<InterfacePrivate> InterfacePrivateHandle;
 
-// Class defintion
+// Class definition
 class Interface : public Core::EventHandler
 {
   CORE_SINGLETON( Interface );

--- a/src/Core/Isosurface/IsosurfaceExporter.cc
+++ b/src/Core/Isosurface/IsosurfaceExporter.cc
@@ -293,7 +293,7 @@ bool IsosurfaceExporter::ExportSTLBinary( const boost::filesystem::path& filenam
     // Get vertices of face
     if (vertex_index1 >= points.size() || vertex_index2 >= points.size() || vertex_index3 >= points.size())
     {
-      throw("verticies are out of points bounds");
+      throw("vertices are out of points bounds");
     }
 
     PointF p1 = points[vertex_index1];

--- a/src/Core/LargeVolume/LargeVolumeCache.cc
+++ b/src/Core/LargeVolume/LargeVolumeCache.cc
@@ -92,7 +92,7 @@ public:
       // If less than 1 GB, use 1 GB.
       if (mem_size < ( static_cast<long long>( 1 ) << 30 )) mem_size = static_cast<long long>( 1 ) << 30;
 
-      // Do not use more than 32 GB, unless explicity requested.
+      // Do not use more than 32 GB, unless explicitly requested.
       this->cache_capacity_ = Core::Min( static_cast<long long>( 32 ) << 30, mem_size );
     }
 

--- a/src/Core/LargeVolume/LargeVolumeConverter.h
+++ b/src/Core/LargeVolume/LargeVolumeConverter.h
@@ -82,7 +82,7 @@ public:
   bool run_phase1( std::string& error );
 
   /// SET_MEM_LIMIT
-  /// How much meory to devote to the conversion process
+  /// How much memory to devote to the conversion process
   void set_mem_limit( long long mem_limit );
 
   /// RUN_PHASE2

--- a/src/Core/Parser/ArrayMathEngine.h
+++ b/src/Core/Parser/ArrayMathEngine.h
@@ -80,7 +80,7 @@ public:
 
   // UPDATE_PROGRESS:
   /// When new information on progress is available this signal is triggered. If this signal is 
-  /// triggered it should end with a value 1.0 indicating that progress reporting has finised.
+  /// triggered it should end with a value 1.0 indicating that progress reporting has finished.
   /// Progress is measured between 0.0 and 1.0.
   update_progress_signal_type update_progress_signal_;
 

--- a/src/Core/Parser/ArrayMathFunctionCatalog.cc
+++ b/src/Core/Parser/ArrayMathFunctionCatalog.cc
@@ -75,7 +75,7 @@ void ArrayMathFunctionCatalog::add_function( ArrayMathFunctionObject function,
 
 // A symmetric function can have its arguments entered in any combination
 // that matches the types. Argmuments can be swapped to match types, or
-// arguments can be swapped to optimize code by removing duplicate functio
+// arguments can be swapped to optimize code by removing duplicate function
 // calls
 
 void ArrayMathFunctionCatalog::add_sym_function( ArrayMathFunctionObject function,

--- a/src/Core/Parser/ArrayMathFunctionCatalog.h
+++ b/src/Core/Parser/ArrayMathFunctionCatalog.h
@@ -65,7 +65,7 @@ public:
   void add_seq_function( ArrayMathFunctionObject function, std::string function_id,
       std::string return_type );
 
-  /// Add a function that wil always output a single
+  /// Add a function that will always output a single
   void add_sgl_function( ArrayMathFunctionObject function, std::string function_id,
       std::string return_type );
 

--- a/src/Core/Parser/ArrayMathProgram.cc
+++ b/src/Core/Parser/ArrayMathProgram.cc
@@ -78,7 +78,7 @@ public:
 
   // UPDATE_PROGRESS:
   // When new information on progress is available this signal is triggered. If this signal is 
-  // triggered it should end with a value 1.0 indicating that progress reporting has finised.
+  // triggered it should end with a value 1.0 indicating that progress reporting has finished.
   // Progress is measured between 0.0 and 1.0.
   update_progress_signal_type update_progress_signal_;
 };

--- a/src/Core/Parser/ArrayMathProgram.h
+++ b/src/Core/Parser/ArrayMathProgram.h
@@ -112,7 +112,7 @@ public:
 
   // UPDATE_PROGRESS:
   /// When new information on progress is available this signal is triggered. If this signal is 
-  /// triggered it should end with a value 1.0 indicating that progress reporting has finised.
+  /// triggered it should end with a value 1.0 indicating that progress reporting has finished.
   /// Progress is measured between 0.0 and 1.0.
   update_progress_signal_type update_progress_signal_;
 

--- a/src/Core/Parser/ArrayMathProgramCode.h
+++ b/src/Core/Parser/ArrayMathProgramCode.h
@@ -50,7 +50,7 @@ typedef boost::function< bool( ArrayMathProgramCode& pc ) > ArrayMathFunctionObj
 //-----------------------------------------------------------------------------
 // Code segment class, all the function calls are based on this class
 // providing the program with input and output variables all located in one
-// piece of memory. Although this class points to auxilary memory block,
+// piece of memory. Although this class points to auxiliary memory block,
 // an effort is made to store them all in the same array, to minimize
 // page swapping
 
@@ -75,7 +75,7 @@ public:
     return this->function_;
   }
 
-  /// Tell the progam where to temporary space has been allocated
+  /// Tell the program where to temporary space has been allocated
   /// for this part of the program
   inline void set_variable( size_t j, float* variable )
   {

--- a/src/Core/Parser/Parser.cc
+++ b/src/Core/Parser/Parser.cc
@@ -138,7 +138,7 @@ public:
   // returns in var_name
   bool scan_variable_name( std::string& expression, std::string& var_name );
 
-  // Scan for a string. A srting is a piece of code between quotes e.g. "foo"
+  // Scan for a string. A string is a piece of code between quotes e.g. "foo"
   // This function should recognize most escape characters in the string and
   // will translate them as well
   bool scan_constant_string( std::string& expression, std::string& str );
@@ -352,7 +352,7 @@ bool ParserPrivate::split_expression( std::string expression, std::string& varna
   return true;
 }
 
-// The main function for disecting code into a tree
+// The main function for dissecting code into a tree
 bool ParserPrivate::parse_expression_tree( std::string expression, ParserNodeHandle& handle,
   std::string& error )
 {
@@ -1493,7 +1493,7 @@ bool ParserPrivate::scan_equal_sign( std::string& expression )
   {
     if ( esize > 1 )
     {
-      // These indicate different operators adn should be
+      // These indicate different operators and should be
       // ignored, most likely this means there is a syntax error
       // in the code
       if ( expression[ 1 ] == '=' ) return false;
@@ -1512,7 +1512,7 @@ bool ParserPrivate::scan_equal_sign( std::string& expression )
 void ParserPrivate::split_function( std::string& expression, std::string& fun_name, std::vector<
                    std::string >& fun_args )
 {
-  // Get the size of the srting we need to scan
+  // Get the size of the string we need to scan
   size_t esize = expression.size();
   // First detect the function name
   // A function name starts with _A-Za-z
@@ -1565,7 +1565,7 @@ void ParserPrivate::split_function( std::string& expression, std::string& fun_na
         else if ( expression[ idx ] == ')' || expression[ idx ] == ']' )
         {
           paren_cnt--;
-          // if we encounterd end paren_cnt should be zero 
+          // if we encountered end paren_cnt should be zero 
           if ( paren_cnt == 0 )
           {
             // Get the last argument
@@ -1602,7 +1602,7 @@ void ParserPrivate::split_subs( std::string& expression, std::vector< std::strin
                  std::vector< std::string >& step_args, std::vector< std::string >& end_args,
                  std::string& varname )
 {
-  // Get the size of the srting we need to scan
+  // Get the size of the string we need to scan
   size_t esize = expression.size();
 
   int col_count = 0;
@@ -1652,7 +1652,7 @@ void ParserPrivate::split_subs( std::string& expression, std::vector< std::strin
       else if ( expression[ idx ] == ']' )
       {
         brac_cnt--;
-        // if we encounterd end paren_cnt should be zero 
+        // if we encountered end paren_cnt should be zero 
         if ( brac_cnt == 0 )
         {
           // Get the last argument
@@ -2290,7 +2290,7 @@ bool Parser::parse( ParserProgramHandle& program, std::string expressions, std::
 
     // Note we store both the raw code as well as the parsed code,
     // to improve error reporting where we can list the faulty raw expression
-    // and the error together. That way the user should be able to recongize
+    // and the error together. That way the user should be able to recognize
     // the faulty line more easily
   }
 
@@ -2575,7 +2575,7 @@ bool Parser::optimize( ParserProgramHandle& program, std::string& error )
     ++it;
   }
 
-  // Phase 2: run throught the full tree and setup intermediate variables
+  // Phase 2: run through the full tree and setup intermediate variables
   //  for each phase of the computation and translate constant strings and
   //  floats as well into variables.
 
@@ -2752,7 +2752,7 @@ bool Parser::optimize( ParserProgramHandle& program, std::string& error )
       ++fit;
     }
 
-    // Add variables to named and unamed list
+    // Add variables to named and unnamed list
     // They are added here, to prevent a loop
     named_variables[ varname ] = ohandle;
     named_order[ varname ] = order;
@@ -2861,7 +2861,7 @@ bool Parser::optimize( ParserProgramHandle& program, std::string& error )
         fhandle->set_output_var( uhandle );
         uhandle->set_parent( fhandle );
 
-        // Now search for additional occurances of whandle in the sequential list
+        // Now search for additional occurrences of whandle in the sequential list
         // and replace them with uhandle
         ParserScriptVariableHandle xhandle;
 
@@ -3021,7 +3021,7 @@ bool Parser::optimize( ParserProgramHandle& program, std::string& error )
   fit = functions.begin();
   fit_end = functions.end();
 
-  // Sort functions in three different catagories
+  // Sort functions in three different categories
   while ( fit != fit_end )
   {
 
@@ -3053,7 +3053,7 @@ bool Parser::optimize( ParserProgramHandle& program, std::string& error )
   pit = variables.begin();
   pit_end = variables.end();
 
-  // Sort variables in three different catagories
+  // Sort variables in three different categories
   while ( pit != pit_end )
   {
 
@@ -3100,7 +3100,7 @@ bool Parser::optimize( ParserProgramHandle& program, std::string& error )
   ParserScriptVariableHandle xhandle;
   ParserScriptFunctionHandle fhandle;
 
-  // Sort functions in three different catagories
+  // Sort functions in three different categories
   while ( fit != fit_end )
   {
     size_t num_input_vars = ( *fit )->num_input_vars();
@@ -3141,7 +3141,7 @@ bool Parser::optimize( ParserProgramHandle& program, std::string& error )
         if ( flags & SCRIPT_SINGLE_VAR_E ) single_function_list.push_back( fhandle );
         else const_function_list.push_back( fhandle );
 
-        // Now search for additional occurances of whandle in the sequential list
+        // Now search for additional occurrences of whandle in the sequential list
         // and replace them with uhandle
 
         fit2 = sequential_function_list.begin();

--- a/src/Core/Parser/ParserEnums.h
+++ b/src/Core/Parser/ParserEnums.h
@@ -65,7 +65,7 @@ enum
 
 enum
 {
-  /// Define a function as sequential it will be evaluted for each instance in
+  /// Define a function as sequential it will be evaluated for each instance in
   /// the sequence. This one is used for functions without parameters like rand
   /// so they trigger for each case
   PARSER_SEQUENTIAL_FUNCTION_E = 1,

--- a/src/Core/Parser/ParserFunction.h
+++ b/src/Core/Parser/ParserFunction.h
@@ -54,7 +54,7 @@ public:
   /// Virtual destructor so we can do dynamic casts on this class
   virtual ~ParserFunction() {}
 
-  /// Retieve the function ID string
+  /// Retrieve the function ID string
   std::string get_function_id();
 
   /// Retrieve the function return type

--- a/src/Core/State/StateValue.h
+++ b/src/Core/State/StateValue.h
@@ -117,7 +117,7 @@ public:
   {
   }
 
-  // DESTRUCTRO
+  // DESTRUCTOR
   virtual ~StateValue()
   {
   }

--- a/src/Core/Utils/ConnectionHandler.h
+++ b/src/Core/Utils/ConnectionHandler.h
@@ -61,7 +61,7 @@ public:
 /// A simple class for managing connections
 
 /// NOTE: To use this class the derived class needs to call disconnect_all()
-/// in the distructor before any of the structures are deleted.
+/// in the destructor before any of the structures are deleted.
 
 class ConnectionHandler : public boost::noncopyable
 {

--- a/src/Core/Utils/LogStreamer.cc
+++ b/src/Core/Utils/LogStreamer.cc
@@ -66,7 +66,7 @@ LogStreamer::LogStreamer( unsigned int log_flags, std::ostream* stream )
   this->private_ = boost::shared_ptr< LogStreamerPrivate >( 
     new LogStreamerPrivate( log_flags,stream ) );
 
-  // If the internals are detroyed, so should the connection:
+  // If the internals are destroyed, so should the connection:
   // we use the signals2 system to track the shared_ptr and destroy the connection
   // if the object is destroyed. This will ensure that when the slot is called
   // the shared_ptr is locked so that the object is not destroyed while the

--- a/src/Core/Utils/StackBasedVector.h
+++ b/src/Core/Utils/StackBasedVector.h
@@ -36,7 +36,7 @@
 #include <memory>
 #include <vector>
 
-//! This vector type is similar in preformance to the StackVector, but checks
+//! This vector type is similar in performance to the StackVector, but checks
 //! for overflow. In case of overflow memory will be reserved to store data_ 
 
 namespace Core

--- a/src/Core/Utils/StringUtil.h
+++ b/src/Core/Utils/StringUtil.h
@@ -161,7 +161,7 @@ std::string StringToLower( std::string );
 void StripSpaces( std::string& str );
 void StripSurroundingSpaces( std::string& str );
 
-// Function to split a list of options delimited by a characher into a vector of
+// Function to split a list of options delimited by a character into a vector of
 // strings
 std::vector<std::string> SplitString( const std::string& str, const std::string& delimiter );
 

--- a/src/Core/Utils/Variant.cc
+++ b/src/Core/Utils/Variant.cc
@@ -45,7 +45,7 @@ Variant::~Variant()
 
 std::string Variant::export_to_string() const
 {
-  // Export a value that is still typed or has been convereted to a string
+  // Export a value that is still typed or has been converted to a string
   // if typed_value exist, we need to convert it
   if ( this->typed_value_.get() )
   {

--- a/src/Core/Utils/Variant.h
+++ b/src/Core/Utils/Variant.h
@@ -185,7 +185,7 @@ public:
     this->string_value_ = variant.export_to_string();
   }
 
-  // desctructor
+  // destructor
   virtual ~Variant();
 
   // assignment operator

--- a/src/Core/Volume/Volume.h
+++ b/src/Core/Volume/Volume.h
@@ -162,7 +162,7 @@ public:
   }
 
   // TO_INDEX:
-  /// Compute the index into the data blcok based on a coordinate in index space
+  /// Compute the index into the data block based on a coordinate in index space
   inline size_t to_index( size_t x, size_t y, size_t z ) const
   {
     assert( x < this->nx_ && y < this->ny_ && z < this->nz_ );

--- a/src/Core/VolumeRenderer/VolumeShaderOcclusion.frag
+++ b/src/Core/VolumeRenderer/VolumeShaderOcclusion.frag
@@ -19,7 +19,7 @@ uniform float normalized_slice_distance;
 varying vec2 correction_factor;
 varying vec4 clip_space_pos;
 
-// Vertex postion in world coordinates
+// Vertex position in world coordinates
 varying vec4 world_coord_pos;
 // Clipping planes in world coordinates
 uniform vec4 clip_plane[ 6 ];

--- a/src/Core/VolumeRenderer/VolumeShaderOcclusion.vert
+++ b/src/Core/VolumeRenderer/VolumeShaderOcclusion.vert
@@ -6,7 +6,7 @@ uniform vec3 tex_bbox_size; // Size of texture in world space
 varying vec2 correction_factor;
 varying vec4 clip_space_pos;
 
-// Vertex postion in world coordinates
+// Vertex position in world coordinates
 varying vec4 world_coord_pos;
 
 // Half vector between eye and light source.

--- a/src/Core/VolumeRenderer/VolumeShaderSimple.vert
+++ b/src/Core/VolumeRenderer/VolumeShaderSimple.vert
@@ -12,7 +12,7 @@ varying vec3 half_vector; // Half vector between eye and light source.
 uniform vec2 fog_range;
 varying float fog_depth;
 
-// Vertex postion in world coordinates
+// Vertex position in world coordinates
 varying vec4 world_coord_pos;
 
 void main()
@@ -22,7 +22,7 @@ void main()
 
   if ( enable_lighting )
   {
-    // With headlight, light position is alway at the origin in eye space
+    // With headlight, light position is always at the origin in eye space
     vec3 aux = vec3( -eye_coord_pos );
     light_dir = normalize( aux );
     half_vector = light_dir;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./src/ThirdParty -L nin,parm,provid`